### PR TITLE
🐛 Fix release deletion

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,11 @@ async function deleteReleases() {
   console.log(`👍🏼  all releases deleted successfully!`);
 }
 
-if (shouldDeleteRelease) {
-  deleteReleases();
+async function run() {	
+  if (shouldDeleteRelease) {
+    await deleteReleases();
+  }
+  await deleteTag();
 }
-deleteTag();
+
+run();

--- a/index.js
+++ b/index.js
@@ -59,12 +59,12 @@ async function deleteTag() {
 async function deleteReleases() {
   let releaseIds = [];
   try {
-    const res = await fetch({
+    const data = await fetch({
       ...commonOpts,
-      url: `/repos/${owner}/${repo}/releases`,
+      path: `/repos/${owner}/${repo}/releases`,
       method: "GET",
     });
-    releaseIds = (res.data || [])
+    releaseIds = (data || [])
       .filter(({ tag_name, draft }) => tag_name === tagName && draft === false)
       .map(({ id }) => id);
   } catch (error) {
@@ -86,7 +86,7 @@ async function deleteReleases() {
     try {
       const _ = await fetch({
         ...commonOpts,
-        url: `/repos/${owner}/${repo}/releases/${releaseId}`,
+        path: `/repos/${owner}/${repo}/releases/${releaseId}`,
         method: "DELETE",
       });
     } catch (error) {

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ console.log(`🏷  given tag is "${tagName}"`);
 
 const tagRef = `refs/tags/${tagName}`;
 
-async function run() {
+async function deleteTag() {
   try {
     const _ = await fetch({
       ...commonOpts,
@@ -54,11 +54,9 @@ async function run() {
     process.exitCode = 1;
     return;
   }
+}
 
-  if (!shouldDeleteRelease) {
-    return;
-  }
-
+async function deleteReleases() {
   let releaseIds = [];
   try {
     const res = await fetch({
@@ -108,4 +106,7 @@ async function run() {
   console.log(`👍🏼  all releases deleted successfully!`);
 }
 
-run();
+if (shouldDeleteRelease) {
+  deleteReleases();
+}
+deleteTag();


### PR DESCRIPTION
With this change, release is correctly deleted:

```
Run bjeanes/delete-tag-and-release@fix-release-deletion
🏷  given tag is "unstable"
🍻  found 1 releases to delete
👍🏼  all releases deleted successfully!
✅  unstable deleted successfully!
```

GitHub converts a release into draft status when its underlying tag is deleted.

This means that the release deletion code ignored candidate releases for deletion
~both~ because it was a draft (`draft === false`) ~and because it was no longer
associated with any tag~.

Additionally, one of the parameters passed to `fetch()` was incorrect (`url` -> `path`) and its return type was misinterpreted.

Fixes #1 