### PR TITLE
Don't fail on tag deletion if tag is already deleted

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,11 @@ async function run() {
     console.log(`✅  ${tagName} deleted successfully!`);
   } catch (error) {
     console.error(`🌶  failed to delete ref ${tagRef} <- ${error.message}`);
-    process.exitCode = 1;
+    if (error.message === "Reference does not exist") {
+      console.error("😕  Proceeding anyway, because tag not existing is the goal");
+    } else {
+      process.exitCode = 1;
+    }
     return;
   }
 


### PR DESCRIPTION
It is inconvenient if the action fails to delete the tag when it doesn't exist. I agree that cathing other errors makes sense, but when the reference is missing, failure is counter-intuitive to me. The end goal is for this reference to not exist, so having this act idempotently would be more useful (at least for my use case).