### PR TITLE
Add option to delete draft releases + README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Add following step to your workflow:
 - uses: dev-drprasad/delete-tag-and-release@v0.2.0
   with:
     delete_release: true # default: false
+    delete_draft_release: true # default: false; only applicable if delete_release == true
     tag_name: v0.1.0 # tag name to delete
     repo: <owner>/<repoName> # target repo (optional). defaults to repo running this action
   env:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Add following step to your workflow:
 ```yaml
 - uses: dev-drprasad/delete-tag-and-release@v0.2.0
   with:
-    delete_release: true # default: false
+    delete_release: true # default: true
     delete_draft_release: true # default: false; only applicable if delete_release == true
     tag_name: v0.1.0 # tag name to delete
     repo: <owner>/<repoName> # target repo (optional). defaults to repo running this action

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: whether to delete release or not
     required: false
     default: true
+  delete_draft_release:
+    description: whether to also delete draft releases
+    required: false
+    default: false
   repo:
     description: target repository as <owner>/<repository>
     required: false

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ if (!process.env.INPUT_TAG_NAME) {
 const tagName = process.env.INPUT_TAG_NAME;
 
 const shouldDeleteRelease = process.env.INPUT_DELETE_RELEASE === "true";
+const shouldDeleteDraftRelease = process.env.INPUT_DELETE_DRAFT_RELEASE === "true";
 
 const commonOpts = {
   host: "api.github.com",
@@ -74,7 +75,7 @@ async function deleteReleases() {
       method: "GET",
     });
     releaseIds = (data || [])
-      .filter(({ tag_name, draft }) => tag_name === tagName && draft === false)
+      .filter(({ tag_name, draft }) => tag_name === tagName && shouldDeleteDraftRelease ? true : (draft === false))
       .map(({ id }) => id);
   } catch (error) {
     console.error(`🌶  failed to get list of releases <- ${error.message}`);


### PR DESCRIPTION
## Add option to also delete draft releases
If delete_draft_release is set to true, the action will also remove draft releases. This only applies if delete_release is set to true as well.

A somewhat related fix: Fix delete_release's wrong default value in README (delete_release is true by default, not false).

I can propose the second commit separately if you don't agree with the option to remove draft releases.
