### PR TITLE
Use major version instead of exact version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Add following step to your workflow:
 
 ```yaml
-- uses: dev-drprasad/delete-tag-and-release@v0.2.1
+- uses: dev-drprasad/delete-tag-and-release@v0.2
   with:
     tag_name: v0.1.0 #(required) tag name to delete 
     delete_release: true #(optional) default: true 


### PR DESCRIPTION
Only set the major version to "force" "copy-paste" users to always use the latest version of the action by default.

This should avoid the need to delete older releases like what happened in #20 